### PR TITLE
Add leaf origin storage in .vqvdb and update decoder

### DIFF
--- a/LeafExtractor.hpp
+++ b/LeafExtractor.hpp
@@ -10,12 +10,12 @@
 #include <string>
 #include <vector>
 
-// Simple NPY file writer for float32 arrays
+// Simple NPY file writer for float32 and int32 arrays
 class NpyWriter {
    public:
-	static bool write(const std::filesystem::path& filename, const std::vector<float>& data, const std::vector<size_t>& shape) {
-		std::ofstream file(filename, std::ios::binary);
-		if (!file) return false;
+        static bool writeFloat32(const std::filesystem::path& filename, const std::vector<float>& data, const std::vector<size_t>& shape) {
+                std::ofstream file(filename, std::ios::binary);
+                if (!file) return false;
 
 		// Calculate total elements and verify data size
 		size_t total_elements = 1;
@@ -51,10 +51,47 @@ class NpyWriter {
 		file.write(header.data(), header_size);
 
 		// Write data
-		file.write(reinterpret_cast<const char*>(data.data()), data.size() * sizeof(float));
+                file.write(reinterpret_cast<const char*>(data.data()), data.size() * sizeof(float));
 
-		return file.good();
-	}
+                return file.good();
+        }
+
+        static bool writeInt32(const std::filesystem::path& filename, const std::vector<int>& data, const std::vector<size_t>& shape) {
+                std::ofstream file(filename, std::ios::binary);
+                if (!file) return false;
+
+                size_t total_elements = 1;
+                for (auto dim : shape) total_elements *= dim;
+                if (data.size() != total_elements) {
+                        std::cerr << "Data size mismatch with shape dimensions\n";
+                        return false;
+                }
+
+                std::string header = "{'descr': '<i4', 'fortran_order': False, 'shape': (";
+                for (size_t i = 0; i < shape.size(); ++i) {
+                        header += std::to_string(shape[i]);
+                        if (i < shape.size() - 1) header += ", ";
+                }
+                header += "), }";
+
+                size_t header_len = header.size() + 1;
+                size_t padding_needed = (64 - ((10 + header_len) % 64)) % 64;
+                header.append(padding_needed, ' ');
+                header.push_back('\n');
+
+                file.write("\x93NUMPY", 6);
+                const uint8_t major = 1, minor = 0;
+                file.write(reinterpret_cast<const char*>(&major), 1);
+                file.write(reinterpret_cast<const char*>(&minor), 1);
+
+                uint16_t header_size = static_cast<uint16_t>(header.size());
+                file.write(reinterpret_cast<char*>(&header_size), 2);
+                file.write(header.data(), header_size);
+
+                file.write(reinterpret_cast<const char*>(data.data()), data.size() * sizeof(int));
+
+                return file.good();
+        }
 };
 
 template <typename GridType>
@@ -106,8 +143,9 @@ bool extractLeafData(const std::string& vdbFilePath, const std::string& gridName
 	const uint32_t leafCount = leafManager.leafCount();
 	std::cout << "Found " << leafCount << " leaf nodes\n";
 
-	// Extract leaf data
-	std::vector<float> leafData(leafCount * GridType::TreeType::LeafNodeType::SIZE);
+        // Extract leaf data and origins
+        std::vector<float> leafData(leafCount * GridType::TreeType::LeafNodeType::SIZE);
+        std::vector<int> originsData(leafCount * 3);
 
 	size_t leafIndex = 0;
 	constexpr int LEAF_DIM = 8;
@@ -115,7 +153,10 @@ bool extractLeafData(const std::string& vdbFilePath, const std::string& gridName
 		const auto& leaf = *iter;
 
 		// Get origin of this leaf
-		Coord origin = leaf.origin();
+                Coord origin = leaf.origin();
+                originsData[leafIndex * 3 + 0] = origin.x();
+                originsData[leafIndex * 3 + 1] = origin.y();
+                originsData[leafIndex * 3 + 2] = origin.z();
 
 		// Extract all voxels in the leaf (8x8x8)
 		for (int z = 0; z < LEAF_DIM; z++) {
@@ -135,15 +176,21 @@ bool extractLeafData(const std::string& vdbFilePath, const std::string& gridName
 		leafIndex++;
 	}
 
-	// Write to NPY file
-	std::vector<size_t> shape = {leafCount, LEAF_DIM, LEAF_DIM, LEAF_DIM};
-	bool success = NpyWriter::write(outputPath, leafData, shape);
+        // Write voxel data
+        std::vector<size_t> shape = {leafCount, LEAF_DIM, LEAF_DIM, LEAF_DIM};
+        bool success = NpyWriter::writeFloat32(outputPath, leafData, shape);
 
-	if (success) {
-		std::cout << "Successfully wrote " << leafCount << " leaf nodes to " << outputPath << std::endl;
-	} else {
-		std::cerr << "Failed to write NPY file\n";
-	}
+        // Also write origins alongside, using the same base name
+        std::filesystem::path originPath = std::filesystem::path(outputPath).replace_extension("_origins.npy");
+        std::vector<size_t> originShape = {leafCount, 3};
+        bool originSuccess = NpyWriter::writeInt32(originPath, originsData, originShape);
 
-	return success;
+        if (success && originSuccess) {
+                std::cout << "Successfully wrote " << leafCount << " leaf nodes to " << outputPath
+                          << " and origins to " << originPath << std::endl;
+        } else {
+                std::cerr << "Failed to write NPY files" << std::endl;
+        }
+
+        return success && originSuccess;
 }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# VQVDB Compression Tools
+
+This repository contains a prototype VQ-VAE based system for compressing OpenVDB
+leaf nodes.  Training utilities are provided in `VQVAE.py` and the runtime
+decoder is implemented in C++.
+
+## Encoding
+
+The `VQVAE.py` script can train a model and compress a dataset of extracted
+leaf nodes.  When supplying an additional `--origins_file` pointing to a Numpy
+array of shape `(N,3)` with integer leaf coordinates, the encoder embeds these
+positions in the output `.vqvdb` file.
+
+Example:
+
+```bash
+python VQVAE.py --input_dir leaves/ --output_dir out/ \
+    --origins_file leaves_origins.npy
+```
+
+The resulting file `compressed_indices.vqvdb` contains both the codebook indices
+and the leaf origins.
+
+## Decoding
+
+`vqvdb_decoder` reconstructs a new VDB grid using a trained model and the
+compressed file:
+
+```bash
+./vqvdb_decoder model.pt compressed_indices.vqvdb template.vdb output.vdb
+```
+
+The decoder no longer needs to derive leaf positions from the template grid;
+it reads them directly from the `.vqvdb` file.  The template VDB is only used
+for metadata such as grid transform, class and name.

--- a/VQVAE_Decoder.cpp
+++ b/VQVAE_Decoder.cpp
@@ -50,11 +50,13 @@ void lookupCodebook(const torch::Tensor& codebook, const torch::Tensor& indices,
 
 // Header for compressed VDB index file
 struct CompressedHeader {
-	char magic[5];                // "VQVDB"
-	uint8_t version;              // Version number
-	uint32_t numEmbeddings;       // Number of codebook entries
-	uint8_t numDimensions;        // Number of dimensions in the index tensor (typically 3 for [d,h,w])
-	std::vector<uint16_t> shape;  // Shape of each index tensor
+        char magic[5];                // "VQVDB"
+        uint8_t version;              // Version number
+        uint32_t numEmbeddings;       // Number of codebook entries
+        uint8_t numDimensions;        // Number of dimensions in the index tensor (typically 3 for [d,h,w])
+        std::vector<uint16_t> shape;  // Shape of each index tensor
+        uint32_t leafCount = 0;       // Number of leaf nodes (optional)
+        std::vector<openvdb::Coord> origins;  // Leaf origins if present
 };
 
 // Read compressed indices from file
@@ -72,10 +74,10 @@ std::vector<torch::Tensor> readCompressedIndices(const std::string& filename, Co
 	}
 
 	// Read version
-	file.read(reinterpret_cast<char*>(&header.version), 1);
-	if (header.version != 1) {
-		throw std::runtime_error("Unsupported file version");
-	}
+        file.read(reinterpret_cast<char*>(&header.version), 1);
+        if (header.version != 1 && header.version != 2) {
+                throw std::runtime_error("Unsupported file version");
+        }
 
 	// Read number of embeddings
 	file.read(reinterpret_cast<char*>(&header.numEmbeddings), sizeof(uint32_t));
@@ -83,9 +85,15 @@ std::vector<torch::Tensor> readCompressedIndices(const std::string& filename, Co
 	// Read number of dimensions
 	file.read(reinterpret_cast<char*>(&header.numDimensions), 1);
 
-	// Read shape dimensions
-	header.shape.resize(header.numDimensions);
-	file.read(reinterpret_cast<char*>(header.shape.data()), header.numDimensions * sizeof(uint16_t));
+        // Read shape dimensions
+        header.shape.resize(header.numDimensions);
+        file.read(reinterpret_cast<char*>(header.shape.data()), header.numDimensions * sizeof(uint16_t));
+
+        if (header.version >= 2) {
+                file.read(reinterpret_cast<char*>(&header.leafCount), sizeof(uint32_t));
+                header.origins.resize(header.leafCount);
+                file.read(reinterpret_cast<char*>(header.origins.data()), header.leafCount * sizeof(openvdb::Coord));
+        }
 
 	// Calculate bits needed per index
 	// (matches the Python bit_length implementation used when writing)
@@ -273,12 +281,12 @@ class VQVAEDecoder {
 		return output;
 	}
 
-	template <typename GridType>
-	void decodeToGrid(const std::string& compressed_file, const std::vector<openvdb::Coord>& leaf_origins,
-	                  typename GridType::Ptr output_grid, int batch_size = 64) {
-		// Read compressed indices
-		CompressedHeader header;
-		std::vector<torch::Tensor> all_indices = readCompressedIndices(compressed_file, header);
+        template <typename GridType>
+        void decodeToGrid(const std::string& compressed_file,
+                          typename GridType::Ptr output_grid, int batch_size = 64) {
+                // Read compressed indices (also loads leaf origins if present)
+                CompressedHeader header;
+                std::vector<torch::Tensor> all_indices = readCompressedIndices(compressed_file, header);
 
 		// Process each batch of indices
 		int total_leaves = 0;
@@ -289,13 +297,13 @@ class VQVAEDecoder {
 			torch::Tensor voxels = decodeIndices(indices);
 
 			// Write voxels to grid
-			int batch_idx_offset = total_leaves;
-			writeVoxelsToGrid<GridType>(
-			    output_grid,
-			    std::vector<openvdb::Coord>(
-			        leaf_origins.begin() + batch_idx_offset,
-			        leaf_origins.begin() + std::min<size_t>(batch_idx_offset + indices.size(0), leaf_origins.size())),
-			    voxels);
+                        int batch_idx_offset = total_leaves;
+                        writeVoxelsToGrid<GridType>(
+                            output_grid,
+                            std::vector<openvdb::Coord>(
+                                header.origins.begin() + batch_idx_offset,
+                                header.origins.begin() + std::min<size_t>(batch_idx_offset + indices.size(0), header.origins.size())),
+                            voxels);
 
 			total_leaves += indices.size(0);
 		}
@@ -315,25 +323,14 @@ class VQVAEDecoder {
 	torch::Device device_;
 };
 
-// Collect all leaf origins from a grid
-template <typename GridType>
-std::vector<openvdb::Coord> collectLeafOrigins(typename GridType::Ptr grid) {
-	std::vector<openvdb::Coord> origins;
-
-	// Iterate over all leaf nodes
-	for (auto leaf_iter = grid->tree().beginLeaf(); leaf_iter; ++leaf_iter) {
-		origins.push_back(leaf_iter->origin());
-	}
-
-	return origins;
-}
 
 int main(int argc, char** argv) {
-	if (argc < 5) {
-		std::cout << "Usage: " << argv[0] << " <model.pt> <compressed_indices.bin> <input_template.vdb> <output.vdb> [grid_name]"
-		          << std::endl;
-		return 1;
-	}
+        if (argc < 5) {
+                std::cout << "Usage: " << argv[0]
+                          << " <model.pt> <compressed_indices.vqvdb> <input_template.vdb> <output.vdb> [grid_name]"
+                          << std::endl;
+                return 1;
+        }
 
 	const std::string model_path = argv[1];
 	const std::string compressed_path = argv[2];
@@ -366,17 +363,14 @@ int main(int argc, char** argv) {
 
 		// Process based on grid type
 		if (auto float_grid = openvdb::GridBase::grid<openvdb::FloatGrid>(base_grid)) {
-			// Get leaf origins
-			std::vector<openvdb::Coord> origins = collectLeafOrigins<openvdb::FloatGrid>(float_grid);
+                        // Create new grid for output
+                        auto output_grid = openvdb::FloatGrid::create();
+                        output_grid->setTransform(float_grid->transformPtr());
+                        output_grid->setGridClass(float_grid->getGridClass());
+                        output_grid->setName(float_grid->getName());
 
-			// Create new grid for output
-			auto output_grid = openvdb::FloatGrid::create();
-			output_grid->setTransform(float_grid->transformPtr());
-			output_grid->setGridClass(float_grid->getGridClass());
-			output_grid->setName(float_grid->getName());
-
-			// Decode compressed data to grid
-			decoder.decodeToGrid<openvdb::FloatGrid>(compressed_path, origins, output_grid);
+                        // Decode compressed data to grid (leaf origins are read from the .vqvdb file)
+                        decoder.decodeToGrid<openvdb::FloatGrid>(compressed_path, output_grid);
 
 			// Write output grid
 			openvdb::io::File file(output_path);


### PR DESCRIPTION
## Summary
- capture leaf origins when extracting VDB leaves and save alongside the voxel data
- allow `VQVAE.py` to embed leaf origins in the `.vqvdb` file
- extend decoder to read origins from the compressed file
- document the new workflow in `README.md`

## Testing
- `python3 -m py_compile VQVAE.py`
- `g++ -fsyntax-only -std=c++17 -I/usr/include VQVAE_Decoder.cpp` *(fails: fatal error: cuda_runtime.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68409e0709288332b639b404f570aa6f